### PR TITLE
モデルスペックの追加

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,9 +40,9 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(
-        :email,
-        :password,
-        :password_confirmation
+      :email,
+      :password,
+      :password_confirmation
     )
   end
 

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :task do
-    
+    title { 'title' }
+    content { 'content' }
+    status { :todo }
+    deadline { 1.week.from_now }
+    association :user
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :task do
-    title { 'title' }
+    sequence(:title, 'title1')
     content { 'content' }
     status { :todo }
     deadline { 1.week.from_now }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    email { 'test1@example.com' }
+    password { 'password' }
+    password_confirmation { 'password' }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { 'test1@example.com' }
+    sequence(:email) { |n| "user_#{n}@example.com" }
     password { 'password' }
     password_confirmation { 'password' }
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,5 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validation' do
+    it 'is valid with all attributes' do end
+    it 'is invalid without title' do end
+    it 'is invalid without status' do end
+    it 'is invalid with a duplicate title' do end
+    it 'is valid with another title' do end
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -3,33 +3,35 @@ require 'rails_helper'
 RSpec.describe Task, type: :model do
   describe 'validation' do
     it 'is valid with all attributes' do 
-      task = FactoryBot.build(:task)
+      task = build(:task)
       expect(task).to be_valid
+      expect(task.errors).to be_empty
     end
 
     it 'is invalid without title' do 
-      task_without_title = FactoryBot.build(:task, title: '')
+      task_without_title = build(:task, title: "")
       expect(task_without_title).to be_invalid
       expect(task_without_title.errors[:title]).to eq ["can't be blank"]
     end
 
     it 'is invalid without status' do
-      task_without_status = FactoryBot.build(:task, status: nil)
+      task_without_status = build(:task, status: nil)
       expect(task_without_status).to be_invalid
       expect(task_without_status.errors[:status]).to eq ["can't be blank"]
     end
 
     it 'is invalid with a duplicate title' do 
       task = FactoryBot.create(:task)
-      task_duplicate_title = FactoryBot.build(:task, title: task.title)
+      task_duplicate_title = build(:task, title: task.title)
       expect(task_duplicate_title).to be_invalid
       expect(task_duplicate_title.errors[:title]).to eq ["has already been taken"]
     end
 
     it 'is valid with another title' do 
       task = FactoryBot.create(:task)
-      task_with_another_title = FactoryBot.build(:task, title: 'another_title')
+      task_with_another_title = build(:task, title: 'another_title')
       expect(task_with_another_title).to be_valid
+      expect(task_with_another_title.errors).to be_empty
     end
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -10,17 +10,20 @@ RSpec.describe Task, type: :model do
     it 'is invalid without title' do 
       task_without_title = FactoryBot.build(:task, title: '')
       expect(task_without_title).to be_invalid
+      expect(task_without_title.errors[:title]).to eq ["can't be blank"]
     end
 
     it 'is invalid without status' do
       task_without_status = FactoryBot.build(:task, status: nil)
       expect(task_without_status).to be_invalid
+      expect(task_without_status.errors[:status]).to eq ["can't be blank"]
     end
 
     it 'is invalid with a duplicate title' do 
       task = FactoryBot.create(:task)
       task_duplicate_title = FactoryBot.build(:task, title: task.title)
       expect(task_duplicate_title).to be_invalid
+      expect(task_duplicate_title.errors[:title]).to eq ["has already been taken"]
     end
 
     it 'is valid with another title' do 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -2,10 +2,31 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   describe 'validation' do
-    it 'is valid with all attributes' do end
-    it 'is invalid without title' do end
-    it 'is invalid without status' do end
-    it 'is invalid with a duplicate title' do end
-    it 'is valid with another title' do end
+    it 'is valid with all attributes' do 
+      task = FactoryBot.build(:task)
+      expect(task).to be_valid
+    end
+
+    it 'is invalid without title' do 
+      task_without_title = FactoryBot.build(:task, title: '')
+      expect(task_without_title).to be_invalid
+    end
+
+    it 'is invalid without status' do
+      task_without_status = FactoryBot.build(:task, status: nil)
+      expect(task_without_status).to be_invalid
+    end
+
+    it 'is invalid with a duplicate title' do 
+      task = FactoryBot.create(:task)
+      task_duplicate_title = FactoryBot.build(:task, title: task.title)
+      expect(task_duplicate_title).to be_invalid
+    end
+
+    it 'is valid with another title' do 
+      task = FactoryBot.create(:task)
+      task_with_another_title = FactoryBot.build(:task, title: 'another_title')
+      expect(task_with_another_title).to be_valid
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
概要

Taskモデルのスペックを追加

確認ポイント

Taskモデルのバリデーションのテストが記載できていること。
エラーメッセージの表示内容も確認していること。
FactoryBotを利用してテストデータを作成していること。
を確認。